### PR TITLE
Speciy model directory and number of threads

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+README.md
+Dockerfile
+examples/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.9-slim AS builder
+
+ENV TZ=Europe/London
+
+WORKDIR /opt/tmbed
+COPY . /opt/tmbed
+
+RUN pip install --no-cache-dir numpy==2.0.2 \
+ && pip install --no-cache-dir h5py==3.13.0 \
+ && pip install --no-cache-dir sentencepiece==0.2.0 \
+ && pip install --no-cache-dir tqdm==4.67.1 \
+ && pip install --no-cache-dir transformers==4.51.3 \
+ && pip install --no-cache-dir typer==0.15.3 \
+ && pip install --no-cache-dir torch==2.7.0+cu128 --extra-index-url https://download.pytorch.org/whl/cu128 \
+ && pip install --no-cache-dir .
+
+FROM python:3.9-slim
+
+ENV TZ=Europe/London
+
+COPY --from=builder /usr/local/lib/python3.9 /usr/local/lib/python3.9
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+ENV CUBLAS_WORKSPACE_CONFIG=:4096:8
+
+ENTRYPOINT ["tmbed"]

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ TMbed has two commands `embed` and `predict` that you can use to generate embedd
 
 ### First run
 
-The first time TMbed is used to generate embeddings, it will automatically download the [ProtT5-XL-U50](https://huggingface.co/Rostlab/prot_t5_xl_half_uniref50-enc) encoder model (2.25 GB) and save it inside the `models/t5/` subdirectory.
+The first time TMbed is used to generate embeddings, it will automatically download the [ProtT5-XL-U50](https://huggingface.co/Rostlab/prot_t5_xl_half_uniref50-enc) encoder model (2.25 GB) and save it inside a `models/t5` subdirectory relative to where the code is installed.
 
 Alternatively, you can use the `download` command to download the ProtT5 model without generating embeddings.
 
@@ -116,6 +116,10 @@ Each batch is constrained by **_N \* L<sup>1.5</sup> &le; BS<sup>1.5</sup>_**, w
 `--use-gpu / --no-use-gpu` controls whether TMbed will try to use an available GPU to speed up computations.
 
 `--cpu-fallback / --no-cpu-fallback` controls whether TMbed will try to use the CPU if it fails to compute the embeddings on GPU.
+
+`--threads` (or `-t`) sets the number of CPU threads used by PyTorch during embedding/prediction (only applies when using the CPU). By default, PyTorch decides how many threads to use based on available system resources.
+
+`--model-dir` (or `-m`) specifies the directory where the ProtT5-XL-U50 encoder model should be downloaded or loaded from.
 
 ### Hardware requirements
 

--- a/tmbed/utils.py
+++ b/tmbed/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import os
 import h5py
 import math
 import torch
@@ -50,6 +50,12 @@ class ARGS:
     batch_size: int = typer.Option(4000, help='Approximated batch size.')
     use_gpu: bool = typer.Option(True, help='Use GPU if available.')
     cpu_fallback: bool = typer.Option(True, help='Use CPU if GPU fails.')
+    num_threads: int = typer.Option(os.cpu_count(), '--threads', '-t',
+                                    help='Number of threads to use with PyTorch '
+                                         'on CPU. Ignored if using GPU.')
+    model_path: Path = typer.Option(None, '--model-dir', '-m', 
+                                    help='Path to the directory where the ProtT5 '
+                                         'model is or will be downloaded.')
 
 
 @dataclass


### PR DESCRIPTION
Hi @BernhoferM,

Thanks for developing TMbed. I am currently exploring whether we can integrate it in InterProScan, and while testing, I ran into two small limitations that can cause issues in some environments, so this PR introduces the following improvements:

- New `--model-dir` (`-m`) option: allows to specify the directory where the ProtT5 model is downloaded and/or loaded from. By default, the model is saved to a `models/t5` subdirectory relative to where the TMbed code is installed. This can be problematic in environments where the install location is on a read-only or low-storage filesystem (we have something like this at EMBL-EBI).
- New `--threads` (`-t`) option: lets users control the number of CPU threads used by PyTorch. While GPU is recommended, there are cases where running on CPU is necessary, such as on personal devices without a GPU, small-scale predictions, or when GPU nodes are limited in a cluster. Without this option, PyTorch tends to use all available CPU cores, which might not be desirable.

Additionally, I’ve added a Dockerfile to enable running TMbed easily in containerized environments. If you want to try the image, it's available on [Docker Hub](https://hub.docker.com/r/matblum/tmbed).

Best